### PR TITLE
React 16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "classnames": "^2.2.5",
     "eslint": "^3.10.2",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
@@ -73,20 +72,16 @@
     "git-prepush-hook": "^1.0.1",
     "jest": "^17.0.3",
     "lodash": "^4.17.2",
-    "react": "^15.4.1",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "reactabular-resizable": "^8.4.0",
     "redux": "^3.6.0",
     "rimraf": "^2.5.4",
-    "searchtabular": "^1.3.2",
-    "sortabular": "^1.1.0",
-    "treetabular": "^2.0.0",
     "webpack-merge": "^2.3.1"
   },
   "peerDependencies": {
     "lodash": ">= 3.0.0 < 5.0.0",
-    "react": ">= 0.11.2 < 16.0.0",
+    "react": ">= 0.11.2 < 17.0.0",
     "redux": ">= 3.0.0 < 5.0.0"
   },
   "pre-push": [

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "9.1.2",
   "description": "Easy, opinionated wrapper for Reactabular",
   "scripts": {
-    "test:all": "npm test && npm run test:lint",
+    "pretest": "npm run test:lint",
     "test": "jest --",
     "test:coverage": "jest --coverage --",
     "test:lint": "eslint . --ext .js --cache",
     "test:watch": "jest --watch --",
     "dist:build": "rimraf ./dist && babel ./src --out-dir ./dist",
-    "preversion": "npm run test:all && npm run dist:build && git commit --allow-empty -am \"Update dist\""
+    "preversion": "npm run test && npm run dist:build && git commit --allow-empty -am \"Update dist\""
   },
   "main": "dist",
   "repository": {
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "prop-types": "^15.6.0",
     "react-dnd": "^2.1.4",
     "reactabular-column-extensions": ">= 8.0.0 < 9.0.0",
     "reactabular-dnd": ">= 8.0.0 < 9.0.0",
@@ -59,7 +60,7 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
-    "babel-jest": "^17.0.2",
+    "babel-jest": "^21.2.0",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015": "^6.18.0",
@@ -70,7 +71,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.7.1",
     "git-prepush-hook": "^1.0.1",
-    "jest": "^17.0.3",
+    "jest": "^21.2.1",
     "lodash": "^4.17.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,0 +1,7 @@
+import { Table, bindColumns, processRows } from '../index';
+
+it('should export an API', () => {
+  expect(Table).toEqual(expect.any(Function));
+  expect(bindColumns).toEqual(expect.any(Function));
+  expect(processRows).toEqual(expect.any(Function));
+});

--- a/src/types.js
+++ b/src/types.js
@@ -1,30 +1,30 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 
 const globalWindow = window;
 
 const propTypes = {
-  window: React.PropTypes.object, // DOM window
-  columns: React.PropTypes.array,
-  rows: React.PropTypes.array,
-  headerRows: React.PropTypes.array,
-  rowKey: React.PropTypes.string.isRequired,
-  query: React.PropTypes.object,
-  sortingColumns: React.PropTypes.object,
-  headerExtra: React.PropTypes.any,
-  tableWidth: React.PropTypes.any.isRequired,
-  tableHeight: React.PropTypes.any.isRequired,
-  classNames: React.PropTypes.object,
-  props: React.PropTypes.object,
-  styles: React.PropTypes.object,
-  components: React.PropTypes.object,
+  window: PropTypes.object, // DOM window
+  columns: PropTypes.array,
+  rows: PropTypes.array,
+  headerRows: PropTypes.array,
+  rowKey: PropTypes.string.isRequired,
+  query: PropTypes.object,
+  sortingColumns: PropTypes.object,
+  headerExtra: PropTypes.any,
+  tableWidth: PropTypes.any.isRequired,
+  tableHeight: PropTypes.any.isRequired,
+  classNames: PropTypes.object,
+  props: PropTypes.object,
+  styles: PropTypes.object,
+  components: PropTypes.object,
   // Custom tree fields
-  idField: React.PropTypes.string,
-  parentField: React.PropTypes.string,
+  idField: PropTypes.string,
+  parentField: PropTypes.string,
   // Handlers
-  onRow: React.PropTypes.func,
-  onMoveRow: React.PropTypes.func,
-  onWidth: React.PropTypes.func,
-  onSelectRow: React.PropTypes.func
+  onRow: PropTypes.func,
+  onMoveRow: PropTypes.func,
+  onWidth: PropTypes.func,
+  onSelectRow: PropTypes.func
 };
 
 const defaultProps = {


### PR DESCRIPTION
* Update peer dependencies to include React 16.
* Load PropTypes from prop-types package.
* Remove duplicate dependencies.
* Add very basic tests.